### PR TITLE
Ability to configure mongo via standard Spring Boot properties

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@ buildscript {
     ext {
         springBootVersion = '1.2.3.RELEASE'
         groovyVersion = '2.4.3'
+        spockVersion = '1.0-groovy-2.4'
     }
     repositories {
         jcenter()
@@ -60,7 +61,10 @@ dependencies {
     }
 
     testCompile 'org.jsoup:jsoup:1.7.3'
-    testCompile('org.spockframework:spock-core:1.0-groovy-2.4') {
+    testCompile("org.spockframework:spock-core:$spockVersion") {
+        exclude module: 'groovy-all'
+    }
+    testCompile("org.spockframework:spock-spring:$spockVersion") {
         exclude module: 'groovy-all'
     }
     testCompile("org.springframework.boot:spring-boot-starter-test")

--- a/src/main/groovy/hello/MongoConfiguration.groovy
+++ b/src/main/groovy/hello/MongoConfiguration.groovy
@@ -1,7 +1,7 @@
 package hello
 
 import com.mongodb.Mongo
-import com.mongodb.MongoOptions
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression
 import org.springframework.context.annotation.Configuration
 import org.springframework.data.authentication.UserCredentials
 import org.springframework.data.mongodb.config.AbstractMongoConfiguration
@@ -10,6 +10,7 @@ import org.springframework.data.mongodb.config.AbstractMongoConfiguration
  * Created by jorge on 03/05/14.
  */
 @Configuration
+@ConditionalOnExpression(value = '#{\'${spring.data.mongodb.host}\'==null}')
 class MongoConfiguration extends AbstractMongoConfiguration {
     String getDatabaseName() {
         "ecosystem"

--- a/src/test/groovy/hello/MongoApplicationPropertiesConfigurationSpec.groovy
+++ b/src/test/groovy/hello/MongoApplicationPropertiesConfigurationSpec.groovy
@@ -1,0 +1,24 @@
+package hello
+
+import com.mongodb.Mongo
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.SpringApplicationConfiguration
+import org.springframework.test.context.ActiveProfiles
+import spock.lang.Specification
+
+/**
+ * Created by gandrianakis on 8/7/2015.
+ */
+@SpringApplicationConfiguration(classes = Application.class)
+@ActiveProfiles("mongoFileConf")
+class MongoApplicationPropertiesConfigurationSpec extends Specification {
+
+    @Autowired
+    Mongo mongo;
+
+    def "make sure that the properties set in the properties file are set in Mongo"() {
+        expect:
+            mongo.authority.serverAddresses._host[0] == 'test'
+            mongo.authority.serverAddresses._port[0] == 27000
+    }
+}

--- a/src/test/groovy/hello/MongoConfigurationSpec.groovy
+++ b/src/test/groovy/hello/MongoConfigurationSpec.groovy
@@ -1,0 +1,23 @@
+package hello
+
+import com.mongodb.Mongo
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.SpringApplicationConfiguration
+import org.springframework.test.context.ActiveProfiles
+import spock.lang.Specification
+
+/**
+ * Created by gandrianakis on 8/7/2015.
+ */
+@SpringApplicationConfiguration(classes = Application.class)
+class MongoConfigurationSpec extends Specification {
+
+    @Autowired
+    Mongo mongo;
+
+    def "make sure that the properties set in the properties file are set in Mongo"() {
+        expect:
+            mongo.authority.serverAddresses._host[0] == 'localhost'
+            mongo.authority.serverAddresses._port[0] == 27017
+    }
+}

--- a/src/test/resources/application-mongoFileConf.properties
+++ b/src/test/resources/application-mongoFileConf.properties
@@ -1,0 +1,2 @@
+spring.data.mongodb.host=test
+spring.data.mongodb.port=27000


### PR DESCRIPTION
This PR gives the application the ability to use the standard Spring Boot [mongo configuration](http://docs.spring.io/spring-boot/docs/1.2.3.RELEASE/reference/htmlsingle/#boot-features-mongodb)
when the `spring.data.mongodb.host` property is set (most easily in `application.properties`).

If the property is set, the configuration in the application's `MongoConfiguration` class is not used at all.
If however the property is not set, then `MongoConfiguration` is used in the standard application fashion
